### PR TITLE
Shell bug fixes

### DIFF
--- a/include/common/host.h
+++ b/include/common/host.h
@@ -1,0 +1,28 @@
+/*
+ Copyright (c) 2017 Tom Hancocks
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+*/
+
+#ifndef COMMON_HOST
+#define COMMON_HOST
+
+const char *host_expand_path(const char *path);
+
+#endif

--- a/src/common/host.c
+++ b/src/common/host.c
@@ -1,0 +1,40 @@
+/*
+ Copyright (c) 2017 Tom Hancocks
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+*/
+
+#include <wordexp.h>
+#include <stdlib.h>
+#include <string.h>
+
+const char *host_expand_path(const char *path)
+{
+    // Perform expansion on the the path.
+    wordexp_t exp_result;
+    wordexp(path, &exp_result, 0);
+
+    unsigned long len = strlen(exp_result.we_wordv[0]);
+    char *result = calloc(len + 1, sizeof(*result));
+    memcpy(result, exp_result.we_wordv[0], len);
+
+    wordfree(&exp_result);
+
+    return result;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -24,12 +24,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <wordexp.h>
 #include <stdio.h>
 
 #include <shell/variable.h>
 #include <shell/scripting.h>
 #include <shell/shell.h>
+#include <common/host.h>
 
 
 #pragma mark - Environment Variables
@@ -94,24 +94,6 @@ shell_variable_t construct_variables_from_environment(const char *env[])
 }
 
 
-#pragma mark - Host Environment Helpers
-
-const char *extract_path(const char *path)
-{
-    // Perform expansion on the the path.
-    wordexp_t exp_result;
-    wordexp(path, &exp_result, 0);
-
-    unsigned long len = strlen(exp_result.we_wordv[0]);
-    char *result = calloc(len + 1, sizeof(*result));
-    memcpy(result, exp_result.we_wordv[0], len);
-
-    wordfree(&exp_result);
-
-    return result;
-}
-
-
 #pragma mark - Core
 
 int main(int argc, const char * argv[], const char *env[])
@@ -129,11 +111,11 @@ int main(int argc, const char * argv[], const char *env[])
     while ((c = getopt(argc, (char **)argv, "s:o:")) != -1) {
         switch (c) {
             case 's': // User specified script
-                script_path = extract_path(optarg);
+                script_path = host_expand_path(optarg);
                 break;
 
             case 'o': // User specified image
-                image_path = extract_path(optarg);
+                image_path = host_expand_path(optarg);
                 break;
 
             default:

--- a/src/shell/attach.c
+++ b/src/shell/attach.c
@@ -21,10 +21,12 @@
  */
 
 #include <assert.h>
+#include <stdlib.h>
 
 #include <shell/attach.h>
 #include <shell/shell.h>
 #include <device/virtual.h>
+#include <common/host.h>
 
 void shell_attach(shell_t shell, int argc, const char *argv[])
 {
@@ -42,7 +44,9 @@ void shell_attach(shell_t shell, int argc, const char *argv[])
         return;
     }
 
-    shell->attached_device = device_create(argv[1]);
+    const char *path = host_expand_path(argv[1]);
+    shell->attached_device = device_create(path);
+    free((void *)path);
 }
 
 void shell_detach(shell_t shell, int argc, const char *argv[])

--- a/src/shell/import.c
+++ b/src/shell/import.c
@@ -26,6 +26,7 @@
 
 #include <shell/import.h>
 #include <shell/shell.h>
+#include <common/host.h>
 
 void shell_import(struct shell *shell, int argc, const char *argv[])
 {
@@ -42,10 +43,12 @@ void shell_import(struct shell *shell, int argc, const char *argv[])
     }
 
     // Open the file, get the size and read the data
-    FILE *f = fopen(argv[1], "r");
+    const char *path = host_expand_path(argv[1]);
+    FILE *f = fopen(path, "r");
     fseek(f, 0L, SEEK_END);
     shell->import_buffer_size = (uint32_t)ftell(f);
     fseek(f, 0L, SEEK_SET);
+    free((void *)path);
 
     shell->import_buffer = calloc(shell->import_buffer_size, sizeof(uint8_t));
     fread(shell->import_buffer, sizeof(uint8_t), shell->import_buffer_size, f);


### PR DESCRIPTION
Fix bugs in the shell:

- Paths that refer/belong to the host OS should be expanded and parsed correctly.