### PR TITLE
Implement FAT12 date & time stamps

### DIFF
--- a/include/vfs/node.h
+++ b/include/vfs/node.h
@@ -24,6 +24,7 @@
 #define VFS_NODE
 
 #include <stdint.h>
+#include <time.h>
 
 struct vfs;
 struct vfs_node;
@@ -47,6 +48,9 @@ struct vfs_node {
     uint8_t is_dirty;
     const char *name;
     uint32_t size;
+    time_t creation_time;
+    time_t modification_time;
+    time_t access_time;
     enum vfs_node_attributes attributes;
     enum vfs_node_state state;
     struct vfs_node *next;

--- a/src/fat/fat12.c
+++ b/src/fat/fat12.c
@@ -740,7 +740,8 @@ vfs_node_t fat12_construct_node_for_sfn(vfs_t fs, void *dir_data, uint32_t sfni)
     assert(sfni < bpb->directory_entries);
     
     // Extract the relavent directory entry.
-    fat12_sfn_t sfn = (fat12_sfn_t)dir_data + (sfni * sizeof(*sfn));
+    uintptr_t ptr = (uintptr_t)dir_data + (sfni * sizeof(struct fat12_sfn));
+    fat12_sfn_t sfn = (fat12_sfn_t)ptr;
     const char *sfn_name = (const char *)sfn->name;
     
     // Construct the VFS node and copy out all appropriate entries


### PR DESCRIPTION
This will bring in FAT12 date & time stamps for file metadata. The following scenarios are covered.

- Creation Date & Time (Upon creation)
- Modification Date & Time (Upon creation and write)
- Last Access Date & Time (Upon creation and write. Lacking read functionality currently)l.

This also adds the appropriate fields in to the Virtual File System node to allow use of them in the shell.