### PR TITLE
FAT12 Directory Entry Manipulation

### DIFF
--- a/include/shell/export.h
+++ b/include/shell/export.h
@@ -1,0 +1,30 @@
+/*
+ Copyright (c) 2017 Tom Hancocks
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#ifndef SHELL_EXPORT
+#define SHELL_EXPORT
+
+struct shell;
+
+void shell_export(struct shell *, int, const char *[]);
+
+#endif

--- a/include/shell/read.h
+++ b/include/shell/read.h
@@ -1,0 +1,30 @@
+/*
+ Copyright (c) 2017 Tom Hancocks
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#ifndef SHELL_READ
+#define SHELL_RAD
+
+struct shell;
+
+void shell_read(struct shell *, int, const char *[]);
+
+#endif

--- a/include/shell/rm.h
+++ b/include/shell/rm.h
@@ -1,0 +1,30 @@
+/*
+ Copyright (c) 2017 Tom Hancocks
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#ifndef SHELL_RM
+#define SHELL_RM
+
+struct shell;
+
+void shell_rm(struct shell *, int, const char *[]);
+
+#endif

--- a/include/vfs/interface.h
+++ b/include/vfs/interface.h
@@ -30,18 +30,42 @@ struct vfs;
 struct vfs_directory;
 
 struct vfs_interface {
+    /// Reports the type name of the filesystem. This will be something like
+    /// `fat12` or `ext2`, etc.
     const char *(*type_name)();
+    
+    /// Invokes a formatting of the device as the specified filesystem. A volume
+    /// label and custom bootcode can be provided.
     void (*format_device)(vdevice_t dev, const char *name, uint8_t *bootcode);
+    
+    /// Mounts the filesystem in question. This action may vary from filesystem
+    /// to filesystem, but will generally load all root directory metadata.
     void *(*mount_filesystem)(struct vfs *fs);
+    
+    /// Cleans up the virtual file system and destroys all concrete filesystem
+    /// structures left in place.
     void (*unmount_filesystem)(struct vfs *fs);
+    
+    /// Sets the current working directory of the filesystem.
     void (*set_directory)(struct vfs *fs, struct vfs_directory *dir);
+    
+    /// Gets the current working directory of the filesystem.
     struct vfs_directory *(*get_directory)(struct vfs *fs);
+    
+    /// Create a new directory entry in the current working directory with the
+    /// specified file name and attributes. This is absent any form of data.
     void (*create_file)(struct vfs *fs,
                         const char *filename,
                         enum vfs_node_attributes attributes);
+    
+    /// Create a new directory entry in the current working directory with the
+    /// specified file name and attributes. This is to explicitly create a
+    /// directory.
     void (*create_dir)(struct vfs *fs,
                        const char *name,
                        enum vfs_node_attributes a);
+    
+    /// Write the specified bytes of data to the named file.
     void (*write)(struct vfs *fs, const char *name, void *bytes, uint32_t n);
 };
 

--- a/include/vfs/interface.h
+++ b/include/vfs/interface.h
@@ -67,6 +67,20 @@ struct vfs_interface {
     
     /// Write the specified bytes of data to the named file.
     void (*write)(struct vfs *fs, const char *name, void *bytes, uint32_t n);
+    
+    /// Read the contents of the specified file. This returns the size of the
+    /// file in bytes.
+    uint32_t (*read)(struct vfs *fs, const char *name, void **bytes);
+    
+    /// Force all metadata in the current working directory to be flushed to
+    /// disk.
+    void (*flush_directory)(struct vfs *fs);
+    
+    /// Rename the specified entry in the current working directory.
+    void (*rename)(struct vfs *fs, const char *old, const char *filename);
+    
+    /// Remove the specified enty in the current working directory.
+    void (*remove)(struct vfs *fs, const char *filename);
 };
 
 typedef struct vfs_interface * vfs_interface_t;

--- a/include/vfs/vfs.h
+++ b/include/vfs/vfs.h
@@ -52,4 +52,6 @@ void vfs_mkdir(vfs_t vfs, const char *name);
 
 void vfs_write(vfs_t vfs, const char *name, uint8_t *bytes, uint32_t size);
 
+void vfs_remove(vfs_t vfs, const char *name);
+
 #endif /* vfs_h */

--- a/include/vfs/vfs.h
+++ b/include/vfs/vfs.h
@@ -51,6 +51,7 @@ void vfs_touch(vfs_t vfs, const char *name);
 void vfs_mkdir(vfs_t vfs, const char *name);
 
 void vfs_write(vfs_t vfs, const char *name, uint8_t *bytes, uint32_t size);
+uint32_t vfs_read(vfs_t vfs, const char *name, uint8_t **bytes);
 
 void vfs_remove(vfs_t vfs, const char *name);
 

--- a/src/fat/fat12.c
+++ b/src/fat/fat12.c
@@ -777,8 +777,17 @@ fat12_sfn_t fat12_commit_node_changes_to_sfn(vfs_node_t node)
         sfn->mdate = fat12_date_from_posix(node->modification_time);
         sfn->adate = fat12_date_from_posix(node->access_time);
         
-        const char *sfn_name = fat12_construct_short_name(node->name, 1);
-        fat12_copy_padded_string((void *)sfn->name, sfn_name, ' ', 11);
+        // If the node has been deleted, then just toggle the name bit in the
+        // SFN rather than rebuilding the name. This is due to a slight bug
+        // in the short name constructor which does same strange mangling of
+        // the name...
+        if ((uint8_t)node->name[0] == 0xE5) {
+            sfn->name[0] = 0xe5;
+        }
+        else {
+            const char *sfn_name = fat12_construct_short_name(node->name, 1);
+            fat12_copy_padded_string((void *)sfn->name, sfn_name, ' ', 11);
+        }
         
         node->is_dirty = 0;
     }

--- a/src/fat/fat12.c
+++ b/src/fat/fat12.c
@@ -95,6 +95,8 @@ void fat12_create_dir(vfs_t fs, const char *name, enum vfs_node_attributes a);
 
 void fat12_remove_file(vfs_t fs, const char *name);
 
+void fat12_flush(vfs_t fs);
+
 
 #pragma mark - VFS Interface Creation
 
@@ -118,6 +120,8 @@ vfs_interface_t fat12_init()
     fs->create_dir = fat12_create_dir;
     
     fs->remove = fat12_remove_file;
+    
+    fs->flush_directory = fat12_flush;
 
     return fs;
 }
@@ -1024,8 +1028,7 @@ void fat12_file_write(vfs_t fs, const char *filename, void *data, uint32_t n)
     }
     
     // Flush the working directory to reflect changes we've made to an entry.
-    fat12_flush_fat_table(fs);
-    fat12_flush_directory(fs);
+    fat12_flush(fs);
 }
 
 
@@ -1221,8 +1224,7 @@ vfs_node_t fat12_get_file(vfs_t fs,
     free((void *)reg);
     
     // Flush the working directory to reflect changes
-    fat12_flush_fat_table(fs);
-    fat12_flush_directory(fs);
+    fat12_flush(fs);
     
     // Return the node to the caller
     return node;
@@ -1269,7 +1271,14 @@ void fat12_remove_file(vfs_t fs, const char *name)
     }
     
     // Finally force the contents of the directory to be flushed to the device.
+    fat12_flush(fs);
+}
+
+
+#pragma mark - Metadata Flushing
+
+void fat12_flush(vfs_t fs)
+{
     fat12_flush_fat_table(fs);
     fat12_flush_directory(fs);
 }
-

--- a/src/shell/commands.c
+++ b/src/shell/commands.c
@@ -37,6 +37,7 @@
 #include <shell/set.h>
 #include <shell/attach.h>
 #include <shell/init.h>
+#include <shell/rm.h>
 
 void shell_register_commands(shell_t shell)
 {
@@ -56,5 +57,6 @@ void shell_register_commands(shell_t shell)
     shell_add_command(shell, shell_command_create("attach", shell_attach));
     shell_add_command(shell, shell_command_create("detach", shell_detach));
     shell_add_command(shell, shell_command_create("init", shell_init_dev));
+    shell_add_command(shell, shell_command_create("rm", shell_rm));
 }
 

--- a/src/shell/commands.c
+++ b/src/shell/commands.c
@@ -38,6 +38,7 @@
 #include <shell/attach.h>
 #include <shell/init.h>
 #include <shell/rm.h>
+#include <shell/read.h>
 
 void shell_register_commands(shell_t shell)
 {
@@ -50,6 +51,7 @@ void shell_register_commands(shell_t shell)
     shell_add_command(shell, shell_command_create("touch", shell_touch));
     shell_add_command(shell, shell_command_create("import", shell_import));
     shell_add_command(shell, shell_command_create("write", shell_write));
+    shell_add_command(shell, shell_command_create("read", shell_read));
     shell_add_command(shell, shell_command_create("mkdir", shell_mkdir));
     shell_add_command(shell, shell_command_create("ls", shell_ls));
     shell_add_command(shell, shell_command_create("set", shell_set));

--- a/src/shell/commands.c
+++ b/src/shell/commands.c
@@ -39,6 +39,7 @@
 #include <shell/init.h>
 #include <shell/rm.h>
 #include <shell/read.h>
+#include <shell/export.h>
 
 void shell_register_commands(shell_t shell)
 {
@@ -50,6 +51,7 @@ void shell_register_commands(shell_t shell)
     shell_add_command(shell, shell_command_create("unmount", shell_unmount));
     shell_add_command(shell, shell_command_create("touch", shell_touch));
     shell_add_command(shell, shell_command_create("import", shell_import));
+    shell_add_command(shell, shell_command_create("export", shell_export));
     shell_add_command(shell, shell_command_create("write", shell_write));
     shell_add_command(shell, shell_command_create("read", shell_read));
     shell_add_command(shell, shell_command_create("mkdir", shell_mkdir));

--- a/src/shell/export.c
+++ b/src/shell/export.c
@@ -1,0 +1,60 @@
+/*
+ Copyright (c) 2017 Tom Hancocks
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <shell/export.h>
+#include <shell/shell.h>
+#include <common/host.h>
+
+void shell_export(struct shell *shell, int argc, const char *argv[])
+{
+    assert(shell);
+    
+    if (argc != 2) {
+        fprintf(stderr,
+                "Expected a single argument for the path to export to.\n");
+        return;
+    }
+    
+    if (!shell->import_buffer) {
+        return;
+    }
+    
+    // Open the file, get the size and read the data
+    const char *path = host_expand_path(argv[1]);
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        fprintf(stderr, "Could not create the specified file\n");
+        return;
+    }
+    free((void *)path);
+    
+    fwrite(shell->import_buffer, shell->import_buffer_size, 1, f);
+    fflush(f);
+    fclose(f);
+    
+    printf("Exported %d bytes from the internal buffer\n",
+           shell->import_buffer_size);
+}

--- a/src/shell/ls.c
+++ b/src/shell/ls.c
@@ -44,6 +44,14 @@ void shell_ls(shell_t shell, int argc, const char *argv[])
         printf("%c", vfsa & vfs_node_hidden_attribute ? 'H' : '-');
         printf("%c", vfsa & vfs_node_read_only_attribute ? 'R' : '-');
         printf("%c", vfsa & vfs_node_system_attribute ? 'S' : '-');
+        
+        // Get the modification date of the file
+        time_t mod = node->modification_time;
+        struct tm ts = *localtime(&mod);
+        char date_buf[80];
+        strftime(date_buf, sizeof(date_buf), "%Y-%m-%d %H:%M:%S", &ts);
+        printf(" %s", date_buf);
+        
         printf(" %08dB ", node->size);
         printf("%s\n", node->name);
         node = node->next;

--- a/src/shell/read.c
+++ b/src/shell/read.c
@@ -1,0 +1,49 @@
+/*
+ Copyright (c) 2017 Tom Hancocks
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include <shell/read.h>
+#include <shell/shell.h>
+#include <vfs/vfs.h>
+
+void shell_read(struct shell *shell, int argc, const char *argv[])
+{
+    assert(shell);
+    
+    if (argc != 2) {
+        fprintf(stderr, "Expected a single argument for the file name.\n");
+        return;
+    }
+    
+    if (shell->import_buffer) {
+        free(shell->import_buffer);
+        shell->import_buffer = NULL;
+    }
+    
+    shell->import_buffer_size = vfs_read(shell->device_filesystem,
+                                         argv[1],
+                                         &shell->import_buffer);
+    
+    printf("Read %d bytes from the device.\n", shell->import_buffer_size);
+}

--- a/src/shell/rm.c
+++ b/src/shell/rm.c
@@ -1,0 +1,40 @@
+/*
+ Copyright (c) 2017 Tom Hancocks
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#include <assert.h>
+
+#include <shell/rm.h>
+#include <shell/shell.h>
+
+#include <vfs/vfs.h>
+
+void shell_rm(shell_t shell, int argc, const char *argv[])
+{
+    assert(shell);
+    
+    if (argc != 2) {
+        fprintf(stderr, "Expected a single argument for the file name.\n");
+        return;
+    }
+    
+    vfs_remove(shell->device_filesystem, argv[1]);
+}

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -113,6 +113,13 @@ void vfs_mkdir(vfs_t vfs, const char *name)
 
 void vfs_write(vfs_t vfs, const char *name, uint8_t *bytes, uint32_t size)
 {
+    assert(vfs);
     vfs_touch(vfs, name);
     vfs->filesystem_interface->write(vfs, name, bytes, size);
+}
+
+void vfs_remove(vfs_t vfs, const char *name)
+{
+    assert(vfs);
+    vfs->filesystem_interface->remove(vfs, name);
 }

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -118,6 +118,12 @@ void vfs_write(vfs_t vfs, const char *name, uint8_t *bytes, uint32_t size)
     vfs->filesystem_interface->write(vfs, name, bytes, size);
 }
 
+uint32_t vfs_read(vfs_t vfs, const char *name, uint8_t **bytes)
+{
+    assert(vfs);
+    return vfs->filesystem_interface->read(vfs, name, (void **)bytes);
+}
+
 void vfs_remove(vfs_t vfs, const char *name)
 {
     assert(vfs);


### PR DESCRIPTION
This will introduce the following features into the FAT12 implementation:

- Removing files/directories. (This will technically leave orphaned directories, as a recursive delete will need to occur for this to work. However this should be accomplished in the VFS or even the Shell commands.)
- Force flushing meta data changes to disk.
- Reading the contents of files.